### PR TITLE
fix: SDCOSMO-3073 

### DIFF
--- a/create-keycloak-realm/main.tf
+++ b/create-keycloak-realm/main.tf
@@ -173,7 +173,7 @@ resource "keycloak_openid_client" "automation-client" {
   client_id                = "automation-client"
   name                     = "automation-client"
   enabled                  = true
-  standard_flow_enabled    = false
+  standard_flow_enabled    = true
   access_type              = "CONFIDENTIAL"
   service_accounts_enabled = true
   login_theme              = "keycloak"
@@ -214,7 +214,7 @@ resource "keycloak_openid_client" "cosmotech-api-client" {
   client_id                = "cosmotech-api-client"
   name                     = "cosmotech-api-client"
   enabled                  = true
-  standard_flow_enabled    = false
+  standard_flow_enabled    = true
   access_type              = "CONFIDENTIAL"
   service_accounts_enabled = true
   login_theme              = "keycloak"

--- a/create-postgresql-db/output.tf
+++ b/create-postgresql-db/output.tf
@@ -32,7 +32,7 @@ output "out_postgres_admin_username" {
 }
 
 output "out_postgres_admin_password" {
-  value     = data.kubernetes_secret.postgres_config.data.cosmotech-api-writer-password
+  value     = data.kubernetes_secret.postgres_config.data.cosmotech-api-admin-password
   sensitive = true
 }
 

--- a/create-seaweedfs/values.yaml
+++ b/create-seaweedfs/values.yaml
@@ -22,7 +22,6 @@ externalDatabase:
   database: "${POSTGRESQL_DATABASE}"
   user: "${POSTGRESQL_USERNAME}"
   existingSecret: "${POSTGRESQL_SECRET}"
-  waitForDatabaseEnabled: false
 volume:
   dataVolumes:
   - name: data-0

--- a/create-seaweedfs/values.yaml
+++ b/create-seaweedfs/values.yaml
@@ -22,6 +22,7 @@ externalDatabase:
   database: "${POSTGRESQL_DATABASE}"
   user: "${POSTGRESQL_USERNAME}"
   existingSecret: "${POSTGRESQL_SECRET}"
+  waitForDatabaseEnabled: false
 volume:
   dataVolumes:
   - name: data-0


### PR DESCRIPTION
Bugs fix : 
- fix  SDCOSMO-3073 
- activate standard flow in Keycloak for client
- Set `waitForDatabaseEnabled=false` for SeaweedFS (without this, the filter tries to pull PostgreSQL images, causing an error)
`seaweedfs-sphinx-s3-filer-0 Init:ImagePullBackOff 
Warning Failed 11s (x3 over 51s) kubelet Failed to pull image "docker.io/bitnami/postgresql:17.4.0-debian-12-r4": rpc error: code = NotFound desc = failed to pull and unpack image "docker. ││ io/bitnami/postgresql:17.4.0-debian-12-r4": failed to resolve reference "docker.io/bitnami/postgresql:17.4.0-debian-12-r4": docker.io/bitnami/postgresql:17.4.0-debian-12-r4: not found ││ Warning Failed 11s (x3 over 51s) kubelet Error: ErrImagePull`